### PR TITLE
fix findGoBin panic when /usr/local contains folders with one char e.…

### DIFF
--- a/start/start.go
+++ b/start/start.go
@@ -258,7 +258,7 @@ func findGoBin(goBin *string, path string) {
 
 	for _, dir := range dirs {
 		// Check if directory name starts with `go`.
-		if dir.Name()[:2] != "go" || !dir.IsDir() {
+		if len(dir.Name()) > 1 && dir.Name()[:2] != "go" || !dir.IsDir() {
 			continue
 		}
 


### PR DESCRIPTION
In the scenario where '/usr/local' contains a directory with a name consisting of only a single character e.g. /usr/local/n/, the findGoBin function ends with a panic.

```
go run ./start/start.go -env ./cfg/env.yaml

Generating `config/env.yaml` and exiting.

panic: runtime error: slice bounds out of range [:2] with length 1

goroutine 1 [running]:
main.findGoBin(0xc00015dd10, {0x5b1811, 0xa})
        /home/dac/Sources/go/OS-NVR/start/start.go:261 +0x1e8
main.configData({0xc00016a060, 0x28})
        /home/dac/Sources/go/OS-NVR/start/start.go:239 +0x85
main.genConfigFile({0xc00016a060, 0x28})
        /home/dac/Sources/go/OS-NVR/start/start.go:208 +0x171
main.start()
        /home/dac/Sources/go/OS-NVR/start/start.go:58 +0x3d9
main.main()
        /home/dac/Sources/go/OS-NVR/start/start.go:30 +0x13
exit status 2
```